### PR TITLE
Docker image build from official Postgres image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM postgres:16.2-bookworm
+
+ENV MQTT_BROKER 127.0.0.1
+ENV POSTGRES_PASSWORD 123password
+
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y python3 python3-pip python3-venv \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /mqtt-pg-logger
+COPY . /mqtt-pg-logger/
+COPY sql/table.sql /docker-entrypoint-initdb.d/00_table.sql
+COPY sql/convert.sql /docker-entrypoint-initdb.d/01_convert.sql
+COPY sql/trigger.sql /docker-entrypoint-initdb.d/02_trigger.sql
+
+COPY entrypoint.sh /
+RUN chmod +x /entrypoint.sh
+
+WORKDIR /mqtt-pg-logger
+RUN python3 -m venv venv \
+    && . ./venv/bin/activate \
+    && pip install -r requirements.txt
+
+EXPOSE 5432
+
+ENTRYPOINT ["/entrypoint.sh"]
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+[ -n "${MQTT_BROKER}" ] || exit 1
+
+USER=${POSTGRES_USER:-postgres}
+NAME=${POSTGRES_DB:-$USER}
+
+cd /mqtt-pg-logger
+cp mqtt-pg-logger.yaml.sample mqtt-pg-logger.yaml
+chmod 600 mqtt-pg-logger.yaml
+sed -i -e "s/<your[_ ]broker>/${MQTT_BROKER}/g" \
+    -e "s/<your[_ ]database[_ ]password>/${POSTGRES_PASSWORD}/g" \
+    -e "s/<your[_ ]database[_ ]user>/${USER}/g" \
+    -e "s/<your[_ ]database[_ ]name>/${NAME}/g" \
+    mqtt-pg-logger.yaml
+
+docker-entrypoint.sh postgres &
+
+until runuser -l postgres -c 'pg_isready -q'; do sleep 1; done
+
+start-stop-daemon -S -x /mqtt-pg-logger/mqtt-pg-logger.sh -- --config-file /mqtt-pg-logger/mqtt-pg-logger.yaml
+

--- a/mqtt-pg-logger.yaml.sample
+++ b/mqtt-pg-logger.yaml.sample
@@ -14,7 +14,7 @@ mqtt:
 
 database:
     host:                       "localhost"
-    port:                       5435
+    port:                       5432
     user:                       "<your database user>"
     password:                   "<your database password>"
     database:                   "<your database name>"


### PR DESCRIPTION
This PR includes a Dockerfile and entry point script required to produce a combined mqtt-pg-logger/Postgres image. 

Standard parameters are configurable through environment variables as per the official Postgres image. Additionally the MQTT broker address can be set through the environment variable `MQTT_BROKER`.

This image can be pulled from https://hub.docker.com/r/robcasey/mqtt-pg-logger.
